### PR TITLE
clangd setup support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ Sandbox/Generated
 # IDE
 .vscode
 
+/.cache/
+
 # APPLE
 .DS_Store
 *.xcodeproj

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.24)
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 project(
   FuegoSandboxProject
   VERSION 0.1


### PR DESCRIPTION
I use clangd in VS Code.

Clangd uses `compile_commands.json`, in order to generate it I have added `CMAKE_EXPORT_COMPILE_COMMANDS` to CMakeLists.txt

MSVC Generator can't be used in order to generate compile commands file, so I recommend to use Ninja:
```
winget install Ninja-build.Ninja
cmake -G Ninja
```