### PR TITLE
Remove unnecessary method in Swapchain API

### DIFF
--- a/Engine/Fuego/MacOS/Metal/DeviceMetal.h
+++ b/Engine/Fuego/MacOS/Metal/DeviceMetal.h
@@ -17,7 +17,6 @@ public:
     virtual std::unique_ptr<CommandQueue> CreateCommandQueue() override;
     virtual std::unique_ptr<CommandPool> CreateCommandPool(const CommandQueue& queue) override;
     virtual std::unique_ptr<Swapchain> CreateSwapchain(const Surface& surface) override;
-    virtual std::unique_ptr<Swapchain> CreateSwapchain(const Surface& surface, float x, float y, float w, float h) override;
     virtual std::unique_ptr<Shader> CreateShader(std::string_view shaderName, Shader::ShaderType type) override;
     virtual std::unique_ptr<Surface> CreateSurface(const void* window) override;
 

--- a/Engine/Fuego/MacOS/Metal/DeviceMetal.mm
+++ b/Engine/Fuego/MacOS/Metal/DeviceMetal.mm
@@ -53,16 +53,6 @@ std::unique_ptr<Swapchain> DeviceMetal::CreateSwapchain(const Surface& surface)
     return std::make_unique<SwapchainMetal>(surface);
 }
 
-std::unique_ptr<Swapchain> DeviceMetal::CreateSwapchain(const Surface& surface, float x, float y, float w, float h)
-{
-    UNUSED(x);
-    UNUSED(y);
-    UNUSED(w);
-    UNUSED(h);
-
-    return std::make_unique<SwapchainMetal>(surface);
-}
-
 std::unique_ptr<Shader> DeviceMetal::CreateShader(std::string_view shaderName, Shader::ShaderType shaderType)
 {
     UNUSED(shaderType);

--- a/Engine/Fuego/MacOS/Metal/SurfaceMetal.h
+++ b/Engine/Fuego/MacOS/Metal/SurfaceMetal.h
@@ -18,6 +18,11 @@ public:
     SurfaceMetal(const void* window, MTL::Device* device);
     ~SurfaceMetal();
 
+    virtual Rect GetRect() const override
+    {
+        return {0, 0, 0, 0};
+    }
+
     virtual const void* GetNativeHandle() const override;
     MTL::PixelFormat GetPixelFormat() const;
 

--- a/Engine/Fuego/Renderer/Device.h
+++ b/Engine/Fuego/Renderer/Device.h
@@ -22,7 +22,6 @@ public:
     virtual std::unique_ptr<CommandPool> CreateCommandPool(const CommandQueue& queue) = 0;
 
     virtual std::unique_ptr<Swapchain> CreateSwapchain(const Surface& surface) = 0;
-    virtual std::unique_ptr<Swapchain> CreateSwapchain(const Surface& surface, float x, float y, float w, float h) = 0;
 
     virtual std::unique_ptr<Shader> CreateShader(std::string_view shaderName, Shader::ShaderType type) = 0;
     virtual std::unique_ptr<Surface> CreateSurface(const void* window) = 0;

--- a/Engine/Fuego/Renderer/Renderer.cpp
+++ b/Engine/Fuego/Renderer/Renderer.cpp
@@ -131,7 +131,7 @@ void Renderer::UpdateViewport()
     _surface.release();
     _surface = _device->CreateSurface(Fuego::Application::Get().GetWindow().GetNativeHandle());
     _swapchain.release();
-    _swapchain = _device->CreateSwapchain(*_surface, 0, 0, viewport.width, viewport.heigth);
+    _swapchain = _device->CreateSwapchain(*_surface);
 }
 
 }  // namespace Fuego::Renderer

--- a/Engine/Fuego/Renderer/Surface.h
+++ b/Engine/Fuego/Renderer/Surface.h
@@ -5,7 +5,13 @@ namespace Fuego::Renderer
 class Surface
 {
 public:
+    struct Rect
+    {
+        int64_t x, y, width, height;
+    };
+
     virtual ~Surface() = default;
+    virtual Rect GetRect() const = 0;
 
     virtual const void* GetNativeHandle() const = 0;
 };

--- a/Engine/Fuego/Windows/OpenGL/DeviceOpenGL.cpp
+++ b/Engine/Fuego/Windows/OpenGL/DeviceOpenGL.cpp
@@ -211,11 +211,6 @@ std::unique_ptr<Swapchain> DeviceOpenGL::CreateSwapchain(const Surface& surface)
     return std::unique_ptr<Swapchain>(new SwapchainOpenGL(surface));
 }
 
-std::unique_ptr<Swapchain> DeviceOpenGL::CreateSwapchain(const Surface& surface, float x, float y, float w, float h)
-{
-    return std::unique_ptr<Swapchain>(new SwapchainOpenGL(surface, x, y, w, h));
-}
-
 std::unique_ptr<Shader> DeviceOpenGL::CreateShader(std::string_view shaderName, Shader::ShaderType type)
 {
     const std::string shaderCode = Application::Get().FileSystem().OpenFile(std::string(shaderName) + ".glsl");

--- a/Engine/Fuego/Windows/OpenGL/DeviceOpenGL.h
+++ b/Engine/Fuego/Windows/OpenGL/DeviceOpenGL.h
@@ -16,7 +16,6 @@ public:
     virtual std::unique_ptr<CommandPool> CreateCommandPool(const CommandQueue& queue) override;
 
     virtual std::unique_ptr<Swapchain> CreateSwapchain(const Surface& surface) override;
-    virtual std::unique_ptr<Swapchain> CreateSwapchain(const Surface& surface, float x, float y, float w, float h) override;
 
     virtual std::unique_ptr<Shader> CreateShader(std::string_view shaderName, Shader::ShaderType type) override;
     virtual std::unique_ptr<Surface> CreateSurface(const void* window) override;

--- a/Engine/Fuego/Windows/OpenGL/SurfaceOpenGL.cpp
+++ b/Engine/Fuego/Windows/OpenGL/SurfaceOpenGL.cpp
@@ -13,6 +13,17 @@ SurfaceOpenGL::~SurfaceOpenGL()
     ReleaseDC(_window, _hdc);
 }
 
+Surface::Rect SurfaceOpenGL::GetRect() const
+{
+    RECT rect;
+    if (GetClientRect(_window, &rect))
+    {
+        return {rect.left, rect.top, rect.right - rect.left, rect.bottom - rect.top};
+    }
+
+    return {0, 0, 0, 0};
+}
+
 const void* SurfaceOpenGL::GetNativeHandle() const
 {
     return _window;

--- a/Engine/Fuego/Windows/OpenGL/SurfaceOpenGL.h
+++ b/Engine/Fuego/Windows/OpenGL/SurfaceOpenGL.h
@@ -9,6 +9,7 @@ class SurfaceOpenGL final : public Surface
 public:
     SurfaceOpenGL(const void* window);
     virtual ~SurfaceOpenGL() override;
+    virtual Rect GetRect() const override;
 
     virtual const void* GetNativeHandle() const override;
     HDC GetHdc() const;

--- a/Engine/Fuego/Windows/OpenGL/SwapchainOpenGL.cpp
+++ b/Engine/Fuego/Windows/OpenGL/SwapchainOpenGL.cpp
@@ -11,13 +11,8 @@ namespace Fuego::Renderer
 SwapchainOpenGL::SwapchainOpenGL(const Surface& surface)
     : _surface(dynamic_cast<const SurfaceOpenGL&>(surface))
 {
-    glViewport(0, 0, 1280.0f, 1024.0f);
-}
-
-SwapchainOpenGL::SwapchainOpenGL(const Surface& surface, float x, float y, float w, float h)
-    : _surface(dynamic_cast<const SurfaceOpenGL&>(surface))
-{
-    glViewport(x, y, w, h);
+    auto rect = surface.GetRect();
+    glViewport(rect.x, rect.y, rect.width, rect.height);
 }
 
 SwapchainOpenGL::~SwapchainOpenGL()

--- a/Engine/Fuego/Windows/OpenGL/SwapchainOpenGL.h
+++ b/Engine/Fuego/Windows/OpenGL/SwapchainOpenGL.h
@@ -27,6 +27,5 @@ private:
 protected:
     friend class DeviceOpenGL;
     SwapchainOpenGL(const Surface& surface);
-    SwapchainOpenGL(const Surface& surface, float x, float y, float w, float h);
 };
 }  // namespace Fuego::Renderer


### PR DESCRIPTION
We have all the info for a Swapchain creation in the Surface class now.