### PR TITLE
Add macOS stubs and workflow job

### DIFF
--- a/.github/workflows/build_validation.yml
+++ b/.github/workflows/build_validation.yml
@@ -39,3 +39,27 @@ jobs:
       shell: bash
       working-directory: ${{ env.build-output-dir }}
       run: ctest --build-config ${{ matrix.build_type }}
+
+  build-macos:
+    runs-on: macos-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        build_type: [Debug, Release]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set reusable strings for macOS
+      run: echo "build-output-dir=${{ github.workspace }}/build/macos" >> $GITHUB_ENV
+
+    - name: Run CMake configuration script for macOS
+      run: bash ${{ github.workspace }}/Scripts/generate_xcode_project.sh
+
+    - name: Build
+      run: cmake --build ${{ env.build-output-dir }} --config ${{ matrix.build_type }}
+
+    - name: Test
+      working-directory: ${{ env.build-output-dir }}
+      run: ctest --build-config ${{ matrix.build_type }}

--- a/Engine/Fuego/MacOS/CMakeLists.txt
+++ b/Engine/Fuego/MacOS/CMakeLists.txt
@@ -7,6 +7,7 @@ SET(PROJECT_HEADERS
     KeyCodesMacOS.h
     WindowMacOS.h
     FileSystemPathsMacOS.h
+    TimeMacOS.h
     Metal/DeviceMetal.h
     Metal/BufferMetal.h
     Metal/CommandQueueMetal.h
@@ -23,6 +24,7 @@ SET(PROJECT_SOURCES
     EventQueueMacOS.mm
     WindowMacOS.mm
     EntryPointMacOS.mm
+    TimeMacOS.cpp
     Metal/MetalImplementation.cpp
     Metal/DeviceMetal.mm
     Metal/BufferMetal.mm

--- a/Engine/Fuego/MacOS/InputMacOS.h
+++ b/Engine/Fuego/MacOS/InputMacOS.h
@@ -5,7 +5,7 @@
 
 namespace Fuego
 {
-class InputMacOS : public Input, public singleton<InputMacOS>
+class InputMacOS final : public Input, public singleton<InputMacOS>
 {
     friend class singleton<InputMacOS>;
 

--- a/Engine/Fuego/MacOS/InputMacOS.h
+++ b/Engine/Fuego/MacOS/InputMacOS.h
@@ -18,6 +18,6 @@ protected:
     virtual float GetMouseYImpl() const override;
     virtual glm::vec2 GetMouseDirImpl() const override;
 
-    friend class WindowWin;
+    friend class WindowMacOS;
 };
 }  // namespace Fuego

--- a/Engine/Fuego/MacOS/TimeMacOS.cpp
+++ b/Engine/Fuego/MacOS/TimeMacOS.cpp
@@ -1,6 +1,5 @@
 #include "TimeMacOS.h"
 
-#include "Application.h"
 
 std::unique_ptr<Fuego::Time> Fuego::Time::CreateTimeManager(float fixed_time)
 {

--- a/Engine/Fuego/MacOS/TimeMacOS.cpp
+++ b/Engine/Fuego/MacOS/TimeMacOS.cpp
@@ -1,0 +1,22 @@
+#include "TimeMacOS.h"
+
+#include "Application.h"
+
+std::unique_ptr<Fuego::Time> Fuego::Time::CreateTimeManager(float fixed_time)
+{
+    return std::make_unique<Fuego::TimeMacOS>(fixed_time);
+}
+
+Fuego::TimeMacOS::TimeMacOS(float fixed_time)
+    : Time(fixed_time)
+    , timer(std::chrono::steady_clock::now())
+{
+}
+
+void Fuego::TimeMacOS::Tick()
+{
+}
+
+void Fuego::TimeMacOS::calc_delta_time()
+{
+}

--- a/Engine/Fuego/MacOS/TimeMacOS.h
+++ b/Engine/Fuego/MacOS/TimeMacOS.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <chrono>
+
+#include "FuTime.h"
+
+namespace Fuego
+{
+class TimeMacOS : public Time
+{
+public:
+    TimeMacOS(float fixed_time);
+    virtual ~TimeMacOS() override = default;
+
+    virtual void Tick() override;
+
+private:
+    std::chrono::time_point<std::chrono::steady_clock> timer;
+    void calc_delta_time();
+};
+}  // namespace Fuego


### PR DESCRIPTION
## Summary
- add missing TimeMacOS implementation
- fix InputMacOS header typo
- reference new files in macOS CMake
- add macOS job in build_validation workflow
- stub out macOS timer implementation

------
https://chatgpt.com/codex/tasks/task_e_6848980021f8832a99c9431a4e9e82d6